### PR TITLE
Add parallel extraction and string ref detection

### DIFF
--- a/isekai/extractors.py
+++ b/isekai/extractors.py
@@ -3,7 +3,7 @@ import re
 import tempfile
 import time
 from pathlib import Path
-from typing import Literal
+from typing import Any, Literal
 from urllib.parse import urlparse
 
 import requests
@@ -19,7 +19,9 @@ TEXT_MIME_TYPES = {
 
 
 class BaseExtractor:
-    def extract(self, key: Key) -> TextResource | BlobResource | None:
+    def extract(
+        self, key: Key, metadata: dict[str, Any] | None = None
+    ) -> TextResource | BlobResource | None:
         return None
 
 
@@ -36,7 +38,9 @@ class HTTPExtractor(BaseExtractor):
         self.timeout = timeout
         self.no_retry_status_codes = no_retry_status_codes or {404}
 
-    def extract(self, key: Key) -> TextResource | BlobResource | None:
+    def extract(
+        self, key: Key, metadata: dict[str, Any] | None = None
+    ) -> TextResource | BlobResource | None:
         # We only handle keys of type "url"
         if key.type != "url":
             return None

--- a/isekai/pipelines.py
+++ b/isekai/pipelines.py
@@ -151,14 +151,14 @@ class Pipeline:
         )
 
     def _run_extractors(
-        self, key: Key, extractors: list[Any]
+        self, key: Key, metadata: dict[str, Any] | None, extractors: list[Any]
     ) -> TextResource | BlobResource | None:
         """Run extractors on a key and return the first successful result.
 
         This method is designed to run in a thread pool for parallel extraction.
         """
         for extractor in extractors:
-            if extracted_resource := extractor.extract(key):
+            if extracted_resource := extractor.extract(key, metadata):
                 return extracted_resource
         return None
 
@@ -180,7 +180,9 @@ class Pipeline:
             for resource in resources:
                 logger.info(f"Extracting resource: {resource.key}")
                 key = Key.from_string(resource.key)
-                future = executor.submit(self._run_extractors, key, self.extractors)
+                future = executor.submit(
+                    self._run_extractors, key, resource.metadata, self.extractors
+                )
                 future_to_resource[future] = resource
 
             # Process results as they complete

--- a/tests/testapp/models.py
+++ b/tests/testapp/models.py
@@ -16,7 +16,7 @@ from isekai.types import Spec, TextResource
 
 
 class FooBarExtractor(BaseExtractor):
-    def extract(self, key):
+    def extract(self, key, metadata=None):
         if not key.type == "foo":
             return None
 


### PR DESCRIPTION
This PR adds three improvements to the isekai pipeline:

1. **Parallel extraction** - Use ThreadPoolExecutor to extract up to 10 resources concurrently
2. **Metadata parameter for extractors** - Extractors can now access resource metadata
3. **String ref detection** - Fix `Spec.find_refs()` to detect refs embedded in strings